### PR TITLE
Add filters for client cleanup decisions

### DIFF
--- a/DuplicateClientsCleanup/Account.cs
+++ b/DuplicateClientsCleanup/Account.cs
@@ -1,7 +1,7 @@
 ﻿// See https://aka.ms/new-console-template for more information........
 public class Account
 {
-    public ClientModel ClientObj { get; set; } 
-    public string AccountNumber { get; set; }
+    public ClientModel ClientObj { get; set; } = new();
+    public string AccountNumber { get; set; } = string.Empty;
     public bool ShouldDelete { get; set; }
 }

--- a/DuplicateClientsCleanup/ClientDecision.cs
+++ b/DuplicateClientsCleanup/ClientDecision.cs
@@ -1,0 +1,19 @@
+public enum ClientStatus
+{
+    Keep,
+    Review,
+    Delete
+}
+
+public sealed class ClientDecision
+{
+    public ClientDecision(ClientModel client, ClientStatus status)
+    {
+        Client = client;
+        Status = status;
+    }
+
+    public ClientModel Client { get; }
+
+    public ClientStatus Status { get; }
+}

--- a/DuplicateClientsCleanup/ClientFilterOptions.cs
+++ b/DuplicateClientsCleanup/ClientFilterOptions.cs
@@ -1,0 +1,282 @@
+public sealed class ClientFilterOptions
+{
+    private const string DefaultCsvPath = @"C:\rawnew.csv";
+
+    public string CsvPath { get; private set; } = DefaultCsvPath;
+
+    public bool ShowHelp { get; private set; }
+
+    public HashSet<ClientStatus> Statuses { get; } = new();
+
+    public HashSet<string> LinkedStatuses { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public HashSet<int> ClientIds { get; } = new();
+
+    public bool? HasTask { get; private set; }
+
+    public string? AccountContains { get; private set; }
+
+    public string? NameContains { get; private set; }
+
+    public static ClientFilterOptions Parse(string[] args)
+    {
+        var options = new ClientFilterOptions();
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            var argument = args[i];
+
+            if (argument is "--help" or "-h" or "/?")
+            {
+                options.ShowHelp = true;
+                continue;
+            }
+
+            if (argument.StartsWith("?") || (argument.Contains('=') && !argument.StartsWith("--")))
+            {
+                ParseQueryLikeOptions(options, argument.TrimStart('?'));
+                continue;
+            }
+
+            if (!argument.StartsWith("--"))
+            {
+                throw new ArgumentException($"Unknown argument '{argument}'. Use --help to see the supported filters.");
+            }
+
+            string optionName;
+            string optionValue;
+            var separatorIndex = argument.IndexOf('=');
+
+            if (separatorIndex > 0)
+            {
+                optionName = argument[2..separatorIndex];
+                optionValue = argument[(separatorIndex + 1)..];
+            }
+            else
+            {
+                optionName = argument[2..];
+                if (i + 1 >= args.Length)
+                {
+                    throw new ArgumentException($"Missing value for --{optionName}.");
+                }
+
+                optionValue = args[++i];
+            }
+
+            ApplyOption(options, optionName, optionValue);
+        }
+
+        return options;
+    }
+
+    public bool Matches(ClientDecision decision)
+    {
+        var client = decision.Client;
+
+        if (Statuses.Count > 0 && !Statuses.Contains(decision.Status))
+        {
+            return false;
+        }
+
+        if (LinkedStatuses.Count > 0 && !LinkedStatuses.Contains(client.IsLinked ?? string.Empty))
+        {
+            return false;
+        }
+
+        if (ClientIds.Count > 0 && !ClientIds.Contains(client.ClientId))
+        {
+            return false;
+        }
+
+        if (HasTask.HasValue && (client.TaskId != 0) != HasTask.Value)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(AccountContains) &&
+            !(client.AccountNumber ?? string.Empty).Contains(AccountContains, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(NameContains) &&
+            !BuildName(client).Contains(NameContains, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public string Describe()
+    {
+        var filters = new List<string>();
+
+        if (Statuses.Count > 0)
+        {
+            filters.Add($"status={string.Join(",", Statuses.Select(status => status.ToString().ToLowerInvariant()))}");
+        }
+
+        if (LinkedStatuses.Count > 0)
+        {
+            filters.Add($"linked={string.Join(",", LinkedStatuses)}");
+        }
+
+        if (ClientIds.Count > 0)
+        {
+            filters.Add($"clientId={string.Join(",", ClientIds)}");
+        }
+
+        if (HasTask.HasValue)
+        {
+            filters.Add($"hasTask={HasTask.Value.ToString().ToLowerInvariant()}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(AccountContains))
+        {
+            filters.Add($"account={AccountContains}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(NameContains))
+        {
+            filters.Add($"name={NameContains}");
+        }
+
+        return filters.Count == 0 ? "none" : string.Join("; ", filters);
+    }
+
+    public static void WriteUsage()
+    {
+        Console.WriteLine("DuplicateClientsCleanup");
+        Console.WriteLine();
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  dotnet run -- --csv <path> [filters]");
+        Console.WriteLine();
+        Console.WriteLine("Filters:");
+        Console.WriteLine("  --status keep,review,delete  Show only selected cleanup decisions.");
+        Console.WriteLine("  --linked Y,N                  Show only linked or unlinked clients.");
+        Console.WriteLine("  --has-task true|false         Show only clients with or without a task id.");
+        Console.WriteLine("  --account <text>              Match account number text.");
+        Console.WriteLine("  --name <text>                 Match first, middle, or last/corporate name.");
+        Console.WriteLine("  --client-id 12,34             Show only selected client ids.");
+        Console.WriteLine();
+        Console.WriteLine("Query-style filters are also supported:");
+        Console.WriteLine("  dotnet run -- \"status=delete&linked=N&hasTask=false\"");
+    }
+
+    private static void ParseQueryLikeOptions(ClientFilterOptions options, string query)
+    {
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parts = pair.Split('=', 2);
+            var name = Uri.UnescapeDataString(parts[0]);
+            var value = parts.Length == 2 ? Uri.UnescapeDataString(parts[1]) : string.Empty;
+            ApplyOption(options, name, value);
+        }
+    }
+
+    private static void ApplyOption(ClientFilterOptions options, string name, string value)
+    {
+        switch (NormalizeName(name))
+        {
+            case "csv":
+                options.CsvPath = value;
+                break;
+            case "status":
+                AddStatuses(options, value);
+                break;
+            case "linked":
+                AddLinkedStatuses(options, value);
+                break;
+            case "hastask":
+                options.HasTask = ParseBoolean(value, "has-task");
+                break;
+            case "account":
+                options.AccountContains = value;
+                break;
+            case "name":
+                options.NameContains = value;
+                break;
+            case "clientid":
+                AddClientIds(options, value);
+                break;
+            default:
+                throw new ArgumentException($"Unknown filter '{name}'. Use --help to see the supported filters.");
+        }
+    }
+
+    private static void AddStatuses(ClientFilterOptions options, string value)
+    {
+        foreach (var statusValue in SplitValues(value))
+        {
+            if (!Enum.TryParse<ClientStatus>(statusValue, ignoreCase: true, out var status))
+            {
+                throw new ArgumentException($"Unknown status '{statusValue}'. Valid values: keep, review, delete.");
+            }
+
+            options.Statuses.Add(status);
+        }
+    }
+
+    private static void AddLinkedStatuses(ClientFilterOptions options, string value)
+    {
+        foreach (var linkedValue in SplitValues(value))
+        {
+            var normalized = linkedValue.ToUpperInvariant();
+            if (normalized is not ("Y" or "N"))
+            {
+                throw new ArgumentException($"Unknown linked value '{linkedValue}'. Valid values: Y, N.");
+            }
+
+            options.LinkedStatuses.Add(normalized);
+        }
+    }
+
+    private static void AddClientIds(ClientFilterOptions options, string value)
+    {
+        foreach (var idValue in SplitValues(value))
+        {
+            if (!int.TryParse(idValue, out var clientId))
+            {
+                throw new ArgumentException($"Invalid client id '{idValue}'.");
+            }
+
+            options.ClientIds.Add(clientId);
+        }
+    }
+
+    private static bool ParseBoolean(string value, string optionName)
+    {
+        if (bool.TryParse(value, out var parsed))
+        {
+            return parsed;
+        }
+
+        return value.ToLowerInvariant() switch
+        {
+            "1" or "yes" or "y" => true,
+            "0" or "no" or "n" => false,
+            _ => throw new ArgumentException($"Invalid value for {optionName}: '{value}'. Use true or false.")
+        };
+    }
+
+    private static IEnumerable<string> SplitValues(string value)
+    {
+        return value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static string NormalizeName(string name)
+    {
+        return name.Replace("-", string.Empty).Replace("_", string.Empty).ToLowerInvariant();
+    }
+
+    private static string BuildName(ClientModel client)
+    {
+        return string.Join(" ", new[]
+        {
+            client.FirstName,
+            client.MiddleName,
+            client.LastCorpName
+        }.Where(part => !string.IsNullOrWhiteSpace(part)));
+    }
+}

--- a/DuplicateClientsCleanup/ClientModel.cs
+++ b/DuplicateClientsCleanup/ClientModel.cs
@@ -2,12 +2,12 @@
 public class ClientModel
 {
     public int ClientId { get; set; }
-    public string FirstName { get; set; }
-    public string MiddleName { get; set; }
-    public string LastCorpName { get; set; }
-    public string AccountNumber { get; set; }
-    public string IsLinked { get; set; }
-    public string LinkedAccountNumber { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string MiddleName { get; set; } = string.Empty;
+    public string LastCorpName { get; set; } = string.Empty;
+    public string AccountNumber { get; set; } = string.Empty;
+    public string IsLinked { get; set; } = string.Empty;
+    public string LinkedAccountNumber { get; set; } = string.Empty;
     public int TaskId { get; set; }
-    public string FullName { get; set; }
+    public string FullName { get; set; } = string.Empty;
 }

--- a/DuplicateClientsCleanup/Helper.cs
+++ b/DuplicateClientsCleanup/Helper.cs
@@ -10,12 +10,17 @@ namespace DuplicateClientsCleanup
 {
     public class Helper
     {
-        public static void ParseCsv(Dictionary<string, List<ClientModel>> clientDict)
+        public static void ParseCsv(Dictionary<string, List<ClientModel>> clientDict, string csvPath = @"C:\rawnew.csv")
         {
             var csvTable = new DataTable();
             char delimiter = ',';
 
-            using (var csvReader = new CsvReader(new StreamReader(System.IO.File.OpenRead(@"C:\rawnew.csv")), true, delimiter: delimiter))
+            if (!File.Exists(csvPath))
+            {
+                throw new FileNotFoundException($"CSV file was not found: {csvPath}", csvPath);
+            }
+
+            using (var csvReader = new CsvReader(new StreamReader(File.OpenRead(csvPath)), true, delimiter: delimiter))
             {
                 csvTable.Load(csvReader);
             }
@@ -27,12 +32,12 @@ namespace DuplicateClientsCleanup
                     var reader = new ClientModel
                     {
                         ClientId = Convert.ToInt32(csvTable.Rows[i][1]),
-                        FirstName = csvTable.Rows[i][2].ToString(),
-                        MiddleName = csvTable.Rows[i][3].ToString(),
-                        LastCorpName = csvTable.Rows[i][4].ToString(),
-                        AccountNumber = csvTable.Rows[i][5].ToString(),
-                        IsLinked = csvTable.Rows[i][6].ToString(),
-                        LinkedAccountNumber = csvTable.Rows[i][7].ToString(),
+                        FirstName = Convert.ToString(csvTable.Rows[i][2]) ?? string.Empty,
+                        MiddleName = Convert.ToString(csvTable.Rows[i][3]) ?? string.Empty,
+                        LastCorpName = Convert.ToString(csvTable.Rows[i][4]) ?? string.Empty,
+                        AccountNumber = Convert.ToString(csvTable.Rows[i][5]) ?? string.Empty,
+                        IsLinked = Convert.ToString(csvTable.Rows[i][6]) ?? string.Empty,
+                        LinkedAccountNumber = Convert.ToString(csvTable.Rows[i][7]) ?? string.Empty,
                         TaskId = string.IsNullOrWhiteSpace(csvTable.Rows[i][8].ToString()) ? 0 : Convert.ToInt32(csvTable.Rows[i][8])
                     };
 

--- a/DuplicateClientsCleanup/Program.cs
+++ b/DuplicateClientsCleanup/Program.cs
@@ -1,96 +1,128 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
 
-using System.Diagnostics;
 using static DuplicateClientsCleanup.Helper;
 
-List<ClientModel> clients = new List<ClientModel>();
-Dictionary<string, List<ClientModel>> clientDict = new Dictionary<string, List<ClientModel>>();
-List<ClientModel> clientIdsToDelete = new List<ClientModel>();
-List<ClientModel> clientIdsToReview = new List<ClientModel>();
-List<ClientModel> clientIdsToKeep = new List<ClientModel>();
+ClientFilterOptions options;
 
-ParseCsv(clientDict);
+try
+{
+    options = ClientFilterOptions.Parse(args);
+}
+catch (ArgumentException ex)
+{
+    Console.WriteLine(ex.Message);
+    Console.WriteLine();
+    ClientFilterOptions.WriteUsage();
+    return;
+}
+
+if (options.ShowHelp)
+{
+    ClientFilterOptions.WriteUsage();
+    return;
+}
+
+Dictionary<string, List<ClientModel>> clientDict = new();
+List<ClientDecision> decisions = new();
+
+try
+{
+    ParseCsv(clientDict, options.CsvPath);
+}
+catch (Exception ex)
+{
+    Console.WriteLine("Error Parsing CSV: " + ex.Message);
+    return;
+}
 
 foreach (var account in clientDict)
 {
-    Debug.WriteLine($"Account Number : {account.Key}");
-    Debug.WriteLine("");
+    Console.WriteLine($"Account Number : {account.Key}");
+    Console.WriteLine("");
     var totalCount = account.Value.Count;
-    Debug.WriteLine($"Total Clients : {totalCount} ");
+    Console.WriteLine($"Total Clients : {totalCount} ");
     var countOfClientsWithoutTask = account.Value.Where(x => x.TaskId == 0).ToList().Count;
-    Debug.WriteLine($"Clients Without Task : {countOfClientsWithoutTask}");
+    Console.WriteLine($"Clients Without Task : {countOfClientsWithoutTask}");
     var countOfClientsWithTask = account.Value.Where(x => x.TaskId != 0).ToList().Count;
-    Debug.WriteLine($"Clients With Task : {countOfClientsWithTask}");
+    Console.WriteLine($"Clients With Task : {countOfClientsWithTask}");
 
     bool areNamesSimilar = checkSimilarNames(account.Value);
 
     if (countOfClientsWithTask == totalCount)
     {
         // every client for this account has a task -- do not delete -- mark for review
-        Debug.WriteLine("Do not Delete - Marked for Review");
+        Console.WriteLine("Do not Delete - Marked for Review");
         foreach (var client in account.Value)
         {
-            clientIdsToReview.Add(client);
+            decisions.Add(new ClientDecision(client, ClientStatus.Review));
         }
     }
     else if (countOfClientsWithoutTask == totalCount)
     {
         //every client for this account doesnt have a task -- delete only unlinked client
-        Debug.WriteLine("Delete Only unlinked Client");
+        Console.WriteLine("Delete Only unlinked Client");
         foreach (var client in account.Value)
         {
             if (client.IsLinked == "N" && areNamesSimilar)
             {
-                clientIdsToDelete.Add(client);
+                decisions.Add(new ClientDecision(client, ClientStatus.Delete));
             }
             else
             {
-                clientIdsToKeep.Add(client);
+                decisions.Add(new ClientDecision(client, ClientStatus.Keep));
             }
         }
     }
     else
     {
-        Debug.WriteLine("Delete Clients that dont have a task");
+        Console.WriteLine("Delete Clients that dont have a task");
         // some of the clients have a task
         // delete only the clients without task
         foreach (var client in account.Value)
         {
             if (client.TaskId == 0 && areNamesSimilar)
             {
-                clientIdsToDelete.Add(client);
+                decisions.Add(new ClientDecision(client, ClientStatus.Delete));
             }
             else
             {
-                clientIdsToKeep.Add(client);
+                decisions.Add(new ClientDecision(client, ClientStatus.Keep));
             }
         }
     }
-    Debug.WriteLine($"-------------------------------------------------");
+    Console.WriteLine($"-------------------------------------------------");
 }
 
+var filteredDecisions = decisions.Where(options.Matches).ToList();
 
-Console.WriteLine($"Records to Keep {clientIdsToKeep.Count}");
-foreach (var client in clientIdsToKeep)
-{
-    Console.WriteLine($" Client ID : {client.ClientId} | Name: {client.LastCorpName} | Account number : {client.AccountNumber} | Task ID : {client.TaskId}");
-}
+Console.WriteLine($"CSV Path: {options.CsvPath}");
+Console.WriteLine($"Active Filters: {options.Describe()}");
+Console.WriteLine($"Matched Records: {filteredDecisions.Count} of {decisions.Count}");
+Console.WriteLine($"-------------------------------------------------");
 
-Console.WriteLine($"Records to Review {clientIdsToReview.Count}");
-foreach (var client in clientIdsToReview)
-{
-    Console.WriteLine($" Client ID : {client.ClientId} | Name: {client.LastCorpName} | Account number : {client.AccountNumber} | Task ID : {client.TaskId}");
-}
-
-Console.WriteLine($"Number of Clients to Delete {clientIdsToDelete.Count}");
-foreach (var client in clientIdsToDelete)
-{
-    Console.WriteLine($" Client ID : {client.ClientId} | Name: {client.LastCorpName} | Account number : {client.AccountNumber} | Task ID : {client.TaskId}");
-}
+WriteStatusGroup("Records to Keep", filteredDecisions, ClientStatus.Keep);
+WriteStatusGroup("Records to Review", filteredDecisions, ClientStatus.Review);
+WriteStatusGroup("Number of Clients to Delete", filteredDecisions, ClientStatus.Delete);
 
 Console.WriteLine($"-------------------------------------------------");
 Console.WriteLine("Delete Query");
-var list = string.Join(",", clientIdsToDelete.Select(x => x.ClientId.ToString()));
+var list = string.Join(",", filteredDecisions
+    .Where(decision => decision.Status == ClientStatus.Delete)
+    .Select(decision => decision.Client.ClientId.ToString()));
 Console.WriteLine($"delete from client_master where client_id in ({list})");
 Console.WriteLine($"-------------------------------------------------");
+
+static void WriteStatusGroup(string heading, List<ClientDecision> decisions, ClientStatus status)
+{
+    var clients = decisions
+        .Where(decision => decision.Status == status)
+        .Select(decision => decision.Client)
+        .ToList();
+
+    Console.WriteLine($"{heading} {clients.Count}");
+    foreach (var client in clients)
+    {
+        Console.WriteLine($" Client ID : {client.ClientId} | Name: {client.LastCorpName} | Account number : {client.AccountNumber} | Linked : {client.IsLinked} | Task ID : {client.TaskId}");
+    }
+}


### PR DESCRIPTION
## Summary
- add CLI/query-style filters for cleanup status, linked flag, task presence, account number, name, and client IDs
- allow the CSV path to be passed with `--csv` instead of only reading `C:\rawnew.csv`
- keep the existing duplicate-client decision rules, then apply filters to the printed groups and delete query

## Verification
- `dotnet build DuplicateClientsCleanup.sln --no-restore`
- `dotnet run --no-build --project DuplicateClientsCleanup/DuplicateClientsCleanup.csproj -- --csv <sample.csv> --status delete --linked N --has-task false`

Fixes #46